### PR TITLE
hotfix: Fixed ColourTester hidden behind header 🐛

### DIFF
--- a/src/lib/utils/ColourTester.svelte
+++ b/src/lib/utils/ColourTester.svelte
@@ -104,6 +104,7 @@
 		top: 0;
 		left: 0;
 		padding: 4px;
+		z-index: 200;
 	}
 
 	span {


### PR DESCRIPTION
Fixed a very simple bug where ColourTester was hidden behind Header due to incorrect z-indexes.