### PR TITLE
#214, #215, #216 - First iteration improved side filter

### DIFF
--- a/src/lib/atoms/Checkbox.svelte
+++ b/src/lib/atoms/Checkbox.svelte
@@ -1,71 +1,21 @@
 <script>
 	let {
-		sronly = true,
+		sronly = false,
 		id,
 		children,
 		inputClass = '',
 		labelClass = '',
 		checked = '',
 		value = 'on',
-		symbol = '',
     onchange,
 	} = $props();
 </script>
-
-<div style="--symbol: '{symbol}'">
 	<!-- Give label a sr-only class if (sronly) is truthy -->
-	<label for={id} class={[sronly && 'sr-only', labelClass]}>{@render children()}</label>
 	<input {id} type="checkbox" class="no-focus {inputClass}" {onchange} />
-</div>
+	<label for={id} class={[sronly && 'sr-only', labelClass]}>{@render children()}</label>
 
 <style>
-	div {
-		position: relative;
-
-    width: 2rem;
-    height: 2rem;
-
-		&::before {
-			border: 2px solid var(--white);
-      color: var(--black);
-      background-color: var(--white);
-			border-radius: var(--border-radius-pill);
-			text-align: center;
-			padding: 0.4rem 0.65rem;
-			content: var(--symbol);
-			left: 0;
-			position: absolute;
-			top: 0;
-			font-size: 0.8rem;
-			font-weight: var(--font-weight-bold);
-			pointer-events: none;
-
-			transition-property: border, background-color, color;
-			transition-duration: 0.15s;
-			transition-timing-function: ease-in-out;
-		}
-
-    &:has(input:checked)::before {
-			border: 2px solid var(--white);
-			color: var(--white);
-      background-color: var(--brown-dark);
-		}
-
-    &:has(input:focus-visible)::before,
-    &:has(input:hover)::before {
-			border: 2px solid var(--brown-neutral);
-			color: var(--white);
-      background-color: var(--brown-neutral);
-		}
-	}
-
 	input {
-		opacity: 0;
-		height: 2rem;
-		width: 2rem;
 
-		position: absolute;
-		left: 0;
-		top: 0;
 	}
 </style>

--- a/src/lib/atoms/Checkbox.svelte
+++ b/src/lib/atoms/Checkbox.svelte
@@ -8,10 +8,11 @@
 		checked = '',
 		value = 'on',
     onchange,
+    ...rest
 	} = $props();
 </script>
 	<!-- Give label a sr-only class if (sronly) is truthy -->
-	<input {id} type="checkbox" class="no-focus {inputClass}" {onchange} />
+	<input {id} type="checkbox" class="no-focus {inputClass}" {onchange}  {...rest} />
 	<label for={id} class={[sronly && 'sr-only', labelClass]}>{@render children()}</label>
 
 <style>

--- a/src/lib/atoms/Checkbox.svelte
+++ b/src/lib/atoms/Checkbox.svelte
@@ -12,11 +12,8 @@
 	} = $props();
 </script>
 	<!-- Give label a sr-only class if (sronly) is truthy -->
-	<input {id} type="checkbox" class="no-focus {inputClass}" {onchange}  {...rest} />
+	<input {id} type="checkbox" class="no-focus {inputClass}" {onchange} value={id} {...rest} />
 	<label for={id} class={[sronly && 'sr-only', labelClass]}>{@render children()}</label>
 
 <style>
-	input {
-
-	}
 </style>

--- a/src/lib/molecules/FilterSection.svelte
+++ b/src/lib/molecules/FilterSection.svelte
@@ -1,7 +1,7 @@
 <script>
   import Checkbox from '$lib/atoms/Checkbox.svelte';
 
-  let { title, items, onchange } = $props();
+  let { title, items, onchange, name } = $props();
 </script>
 
 <fieldset>
@@ -9,7 +9,7 @@
   <ul>
     {#each items as item}
       <li>
-        <Checkbox id={item} label={item} {onchange}>
+        <Checkbox id={item} label={item} {name} {onchange}>
           {item}
         </Checkbox>
       </li>

--- a/src/lib/molecules/FilterSection.svelte
+++ b/src/lib/molecules/FilterSection.svelte
@@ -1,7 +1,7 @@
 <script>
   import Checkbox from '$lib/atoms/Checkbox.svelte';
 
-  let { title, items } = $props();
+  let { title, items, onchange } = $props();
 </script>
 
 <fieldset>
@@ -9,7 +9,7 @@
   <ul>
     {#each items as item}
       <li>
-        <Checkbox id={item} label={item}>
+        <Checkbox id={item} label={item} {onchange}>
           {item}
         </Checkbox>
       </li>

--- a/src/lib/molecules/FilterSection.svelte
+++ b/src/lib/molecules/FilterSection.svelte
@@ -1,0 +1,39 @@
+<script>
+  import Checkbox from '$lib/atoms/Checkbox.svelte';
+
+  let { title, items } = $props();
+</script>
+
+<fieldset>
+  <legend>{title}</legend>
+  <ul>
+    {#each items as item}
+      <li>
+        <Checkbox id={item} label={item}>
+          {item}
+        </Checkbox>
+      </li>
+    {/each}
+  </ul>
+</fieldset>
+
+<style>
+  fieldset {
+    border: none;
+    padding: 0;
+    margin: var(--spacing-md) 0;
+  }
+
+  legend {
+    font-size: var(--font-size-sm);
+    font-weight: var(--font-weight-bold);
+    margin-bottom: var(--spacing-xs);
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    list-style: none;
+  }
+</style>

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -1,8 +1,9 @@
 <script>
   import { onDestroy, onMount } from 'svelte';
   import { tick } from 'svelte';
+  import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
   
-  let { mapAddresses, javascriptEnabled } = $props();
+  let { mapAddresses} = $props();
   let mapElement = $state(null);
   let map = $state(null);
   let markers = [];
@@ -63,7 +64,7 @@
   });
 </script>
 
-<section class={{ 'js-enabled': javascriptEnabled}}>
+<section class={{ 'js-enabled': javascript.enabled}}>
   <h2 class="sr-only">Adressen op de kaart</h2>
   
   <div bind:this={mapElement}></div>

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -2,7 +2,7 @@
   import { onDestroy, onMount } from 'svelte';
   import { tick } from 'svelte';
   import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
-  
+
   let { mapAddresses} = $props();
   let mapElement = $state(null);
   let map = $state(null);
@@ -73,7 +73,6 @@
     @import 'leaflet/dist/leaflet.css';
     section {
       display:none;
-      margin: -.75rem calc(-1* var(--page-padding)) var(--spacing-md);
       width: calc(100% + 2* var(--page-padding));
       position: relative;
       z-index:1;

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -64,7 +64,7 @@
   });
 </script>
 
-<section class={{ 'js-enabled': javascript.enabled}}>
+<section class={{ 'js-enabled': javascript.enabled, 'map': true }}>
   <h2 class="sr-only">Adressen op de kaart</h2>
   
   <div bind:this={mapElement}></div>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -13,7 +13,7 @@
 <section class="overview">
 	<header>
 		<PostersTitle length={addresses.length} />
-		<Button onclick={() => (filterOpen = !filterOpen)}>Filters</Button>
+		<Button onclick={() => (filterOpen = !filterOpen)} class={$css('filter-button')}>Filters</Button>
 	</header>
 
 	{#await addresses}
@@ -67,6 +67,10 @@
 		padding-top: var(--spacing-lg);
 	}
 
+  .filter-button {
+    display: block !important;
+  }
+
 	@media screen and (min-width: 800px) {
 		div:global(:has(.landscape)) {
 			grid-column: span 2;
@@ -85,6 +89,10 @@
 
     section {
       padding: 0 var(--spacing-md);
+    }
+
+    .filter-button {
+      display: none !important;
     }
 	}
 </style>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -1,18 +1,18 @@
 <script>
 	import PosterCard from '../molecules/PosterCard.svelte';
   import PostersTitle from '$lib/atoms/PostersTitle.svelte';
-	import PostersFilter from '$lib/organisms/PostersFilter.svelte';
+	import Button from '$lib/atoms/Button.svelte';
 
 	import { flip } from "svelte/animate";
   import { fade } from "svelte/transition";
 	import { cubicOut } from "svelte/easing";
 
-	let { addresses = [] } = $props();
+	let { addresses = [], filterOpen } = $props();
 </script>
 
 <header>
   <PostersTitle length={addresses.length} />
-  <PostersFilter />
+  <Button onclick={() => filterOpen = !filterOpen}>Filters</Button>
 </header>
 
 {#await addresses}
@@ -64,8 +64,6 @@
     padding-top: var(--spacing-lg);
   }
 
-	
-  
   @media screen and (min-width: 800px) {
     div:global(:has(.landscape)) {
       grid-column: span 2;

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -1,54 +1,57 @@
 <script>
 	import PosterCard from '../molecules/PosterCard.svelte';
-  import PostersTitle from '$lib/atoms/PostersTitle.svelte';
+	import PostersTitle from '$lib/atoms/PostersTitle.svelte';
 	import Button from '$lib/atoms/Button.svelte';
 
-	import { flip } from "svelte/animate";
-  import { fade } from "svelte/transition";
-	import { cubicOut } from "svelte/easing";
+	import { flip } from 'svelte/animate';
+	import { fade } from 'svelte/transition';
+	import { cubicOut } from 'svelte/easing';
 
 	let { addresses = [], filterOpen } = $props();
 </script>
 
-<header>
-  <PostersTitle length={addresses.length} />
-  <Button onclick={() => filterOpen = !filterOpen}>Filters</Button>
-</header>
+<section class="overview">
+	<header>
+		<PostersTitle length={addresses.length} />
+		<Button onclick={() => (filterOpen = !filterOpen)}>Filters</Button>
+	</header>
 
-{#await addresses}
-	<p>Loading posters...</p>
-{:then addresses}
-	{#if addresses.length > 0}
-		<ul>
-			{#each addresses as address (address.id)}
-      <div transition:fade={{duration: 300, easing: cubicOut}} animate:flip={{duration: 300, easing: cubicOut}}>
-				<PosterCard
-					name={address.person?.[0]?.last_name ?? 'Onbekend'}
-					street={address.street ?? 'Onbekend'}
-					house_number={address.house_number ?? 'Onbekend'}
-					floor={address?.floor}
-					addition={address?.addition}
-					image={address.poster?.covers?.[0]?.directus_files_id?.id ?? ''}
-					width={address.poster?.covers?.[0]?.directus_files_id?.width ?? 419}
-					height={address.poster?.covers?.[0]?.directus_files_id?.height ?? 585}
-					id={address?.id ?? ''}
-				/>
-      </div>
-			{/each}
-		</ul>
-	{:else}
-		<p>
-		  Geen posters gevonden. Probeer de filters te wijzigen, of probeer het later opnieuw.
-		</p>
-	{/if}
-{:catch error}
-	<p>error loading posters: {error.message}</p>
-{/await}
+	{#await addresses}
+		<p>Loading posters...</p>
+	{:then addresses}
+		{#if addresses.length > 0}
+			<ul>
+				{#each addresses as address (address.id)}
+					<div
+						transition:fade={{ duration: 300, easing: cubicOut }}
+						animate:flip={{ duration: 300, easing: cubicOut }}
+					>
+						<PosterCard
+							name={address.person?.[0]?.last_name ?? 'Onbekend'}
+							street={address.street ?? 'Onbekend'}
+							house_number={address.house_number ?? 'Onbekend'}
+							floor={address?.floor}
+							addition={address?.addition}
+							image={address.poster?.covers?.[0]?.directus_files_id?.id ?? ''}
+							width={address.poster?.covers?.[0]?.directus_files_id?.width ?? 419}
+							height={address.poster?.covers?.[0]?.directus_files_id?.height ?? 585}
+							id={address?.id ?? ''}
+						/>
+					</div>
+				{/each}
+			</ul>
+		{:else}
+			<p>Geen posters gevonden. Probeer de filters te wijzigen, of probeer het later opnieuw.</p>
+		{/if}
+	{:catch error}
+		<p>error loading posters: {error.message}</p>
+	{/await}
+</section>
 
 <style>
 	header {
 		display: flex;
-    gap: var(--spacing-md);
+		gap: var(--spacing-md);
 		flex-direction: column;
 		align-items: center;
 		padding: var(--spacing-md) var(--spacing-xs) 0;
@@ -60,24 +63,28 @@
 		padding-top: var(--spacing-sm);
 	}
 
-  p {
-    padding-top: var(--spacing-lg);
-  }
+	p {
+		padding-top: var(--spacing-lg);
+	}
 
-  @media screen and (min-width: 800px) {
-    div:global(:has(.landscape)) {
-      grid-column: span 2;
+	@media screen and (min-width: 800px) {
+		div:global(:has(.landscape)) {
+			grid-column: span 2;
 		}
-  }
-  
-  @media screen and (min-width: 940px) {
-    header {
-      flex-direction: row;
-      justify-content: space-between;
+	}
+
+	@media screen and (min-width: 940px) {
+		header {
+			flex-direction: row;
+			justify-content: space-between;
+		}
+
+		ul {
+			padding-top: var(--spacing-md);
+		}
+
+    section {
+      padding: 0 var(--spacing-md);
     }
-    
-    ul {
-      padding-top: var(--spacing-lg);
-    }
-  }
+	}
 </style>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -43,11 +43,6 @@
 </aside>
 
 <style>
-  /* h3 {
-    margin-top: var(--spacing-md);
-    position: sticky;
-    top: 8rem;
-  } */
 	aside {
     position: sticky;
     top: 6rem;
@@ -60,8 +55,6 @@
 	}
 
 	form {
-    /* position: sticky;
-    top: 8rem; */
 		display: grid;
 		grid-template-columns: 1fr auto;
 		grid-template-rows: auto auto;

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -1,0 +1,53 @@
+<script>
+	import Button from '$lib/atoms/Button.svelte';
+	import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
+</script>
+
+<aside>
+	<form>
+		<Button
+			class={{ 'sr-only': javascript.enabled, highlight: true }}
+			buttonClass={$css('show-on-focus')}
+			type="submit"
+		>
+			Toepassen
+		</Button>
+		<!-- <FilterSection
+			title="Straat"
+			items={[
+				'Straatnaam 1',
+				'Straatnaam 2',
+				'Straatnaam 3',
+				'Straatnaam 4',
+				'Straatnaam 5',
+				'Straatnaam 6',
+				'Straatnaam 7'
+			]}
+		/>
+		<FilterSection
+			title="Naam"
+			items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']}
+		/> -->
+	</form>
+</aside>
+
+<style>
+	aside {
+		display: flex;
+		flex-direction: column;
+		gap: var(--spacing-xs);
+    background-color: var(--white);
+	}
+
+  .show-on-focus:focus-visible {
+		position: static;
+		display: inline-block;
+		width: fit-content;
+		height: fit-content;
+		padding: var(--spacing-xxs) var(--spacing-sm);
+		overflow: visible;
+		clip: auto;
+		white-space: normal;
+		border-width: 0;
+	}
+</style>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -49,8 +49,7 @@
 		background-color: var(--white);
 		box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
 		padding: var(--spacing-md);
-    height: fit-content;
-    max-height: calc(100vh - 6rem);
+    height: calc(100vh - 6rem);
     overflow-y: auto;
 	}
 

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -35,9 +35,9 @@
 		</Button>
 		<div>
 			<FilterSection title="Straat" name="s" items={streetsList} onchange={filterHandler} />
-			<FilterSection title="Naam" name="n" items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']} onchange={filterHandler} />
-      <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} />
-      <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} />
+			<FilterSection title="Naam" name="n" items={['Jacob', 'Vries', 'Kreveld']} onchange={filterHandler} />
+      <!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
+      <!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->
 		</div>
 	</form>
 </aside>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -4,6 +4,8 @@
 	import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
 	import { page } from '$app/state';
 
+	let { streets } = $props();
+
 	// Derive the list of streets from the posters
 	let streetsList = $derived(
 		Array.from(
@@ -33,7 +35,7 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection title="Straat" name="s" items={streetsList} onchange={filterHandler} />
+			<FilterSection title="Straat" name="s" items={streets} onchange={filterHandler} />
 			<FilterSection title="Naam" name="n" items={['Jacob', 'Vries', 'Kreveld']} onchange={filterHandler} />
       <!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
       <!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -34,10 +34,10 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection title="Straat" items={streetsList} onchange={filterHandler} />
-			<FilterSection title="Naam" items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']} onchange={filterHandler} />
-      <FilterSection title="Thema" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} />
-      <FilterSection title="Stolpesteiner" items={['Stolpesteiner']} onchange={filterHandler} />
+			<FilterSection title="Straat" name="s" items={streetsList} onchange={filterHandler} />
+			<FilterSection title="Naam" name="n" items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']} onchange={filterHandler} />
+      <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} />
+      <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} />
 		</div>
 	</form>
 </aside>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -18,7 +18,6 @@
   let form;
 
   function filterHandler(event) {
-    console.log(event);
     form.requestSubmit();
   }
 </script>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -1,10 +1,12 @@
 <script>
+	import FilterSection from '$lib/molecules/FilterSection.svelte';
 	import Button from '$lib/atoms/Button.svelte';
 	import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
 </script>
 
 <aside>
 	<form>
+    <h3>Filters</h3>
 		<Button
 			class={{ 'sr-only': javascript.enabled, highlight: true }}
 			buttonClass={$css('show-on-focus')}
@@ -12,7 +14,7 @@
 		>
 			Toepassen
 		</Button>
-		<!-- <FilterSection
+		<FilterSection
 			title="Straat"
 			items={[
 				'Straatnaam 1',
@@ -27,7 +29,7 @@
 		<FilterSection
 			title="Naam"
 			items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']}
-		/> -->
+		/>
 	</form>
 </aside>
 
@@ -37,7 +39,14 @@
 		flex-direction: column;
 		gap: var(--spacing-xs);
     background-color: var(--white);
+    box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
+    padding: var(--spacing-md);
 	}
+
+  form {
+    position: sticky;
+    top: 8rem;
+  }
 
   .show-on-focus:focus-visible {
 		position: static;

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -2,11 +2,30 @@
 	import FilterSection from '$lib/molecules/FilterSection.svelte';
 	import Button from '$lib/atoms/Button.svelte';
 	import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
+	import { page } from '$app/state';
+
+	// Derive the list of streets from the posters
+	let streetsList = $derived(
+		Array.from(
+			// Remove duplicates
+			new Set(
+				// Get all streets from posters
+				page.data.addresses.map((address) => address.street.trim())
+			)
+		).sort() // Sort alphabetically
+	);
+
+  let form;
+
+  function filterHandler(event) {
+    console.log(event);
+    form.requestSubmit();
+  }
 </script>
 
 <aside>
-	<form>
-    <h3>Filters</h3>
+  <h3>Filters</h3>
+	<form bind:this={form} action="/adressen" data-sveltekit-noscroll>
 		<Button
 			class={{ 'sr-only': javascript.enabled, highlight: true }}
 			buttonClass={$css('show-on-focus')}
@@ -14,41 +33,47 @@
 		>
 			Toepassen
 		</Button>
-		<FilterSection
-			title="Straat"
-			items={[
-				'Straatnaam 1',
-				'Straatnaam 2',
-				'Straatnaam 3',
-				'Straatnaam 4',
-				'Straatnaam 5',
-				'Straatnaam 6',
-				'Straatnaam 7'
-			]}
-		/>
-		<FilterSection
-			title="Naam"
-			items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']}
-		/>
+		<div>
+			<FilterSection title="Straat" items={streetsList} onchange={filterHandler} />
+			<FilterSection title="Naam" items={['Naam 1', 'Naam 2', 'Naam 3', 'Naam 4']} onchange={filterHandler} />
+      <FilterSection title="Thema" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} />
+      <FilterSection title="Stolpesteiner" items={['Stolpesteiner']} onchange={filterHandler} />
+		</div>
 	</form>
 </aside>
 
 <style>
-	aside {
-		display: flex;
-		flex-direction: column;
-		gap: var(--spacing-xs);
-    background-color: var(--white);
-    box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
-    padding: var(--spacing-md);
-	}
-
-  form {
+  /* h3 {
+    margin-top: var(--spacing-md);
     position: sticky;
     top: 8rem;
-  }
+  } */
+	aside {
+    position: sticky;
+    top: 6rem;
+		background-color: var(--white);
+		box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
+		padding: var(--spacing-md);
+    height: fit-content;
+    max-height: calc(100vh - 6rem);
+    overflow-y: auto;
+	}
 
-  .show-on-focus:focus-visible {
+	form {
+    /* position: sticky;
+    top: 8rem; */
+		display: grid;
+		grid-template-columns: 1fr auto;
+		grid-template-rows: auto auto;
+		gap: var(--spacing-md);
+	}
+
+	form > div {
+		grid-column: 0 / 2;
+		grid-row: 2;
+	}
+
+	.show-on-focus:focus-visible {
 		position: static;
 		display: inline-block;
 		width: fit-content;

--- a/src/routes/adressen/+page.js
+++ b/src/routes/adressen/+page.js
@@ -2,51 +2,56 @@ import getDirectusInstance from '$lib/directus';
 import { readItems } from '@directus/sdk';
 
 export async function load({ fetch, url }) {
-  let queryFilters = {};
-  
-  if (url.searchParams.get('straat')) {
-    queryFilters.street = {
-      _icontains: url.searchParams.get('straat')
-    }
-  }
 
-  if (url.searchParams.get('naam')) {
-    queryFilters.person = {
-      '_or': [
-        {
-          'first_name': {
-            '_icontains': url.searchParams.get('naam')
-          }
-        },
-        {
-          'last_name': {
-            '_icontains': url.searchParams.get('naam')
-          }
-        }
-      ]
-    }
-  }
+  let streetFilters = [];
+  let nameFilters = [];
+  // Extract the values by key and add them to their respective arrays
+  url.searchParams.forEach((value, key) => {
+    (key == 's') && (streetFilters.push(value));
+    (key == 'n') && (nameFilters.push(value));
+  });
 
-  const queryFields = [
-    'id',
-    'street',
-    'house_number',
-    'floor',
-    'addition',
-    'map',
-    { person: ['first_name', 'last_name'] },
-    { poster: [
-        'id',
-        { covers: [
-            'directus_files_id.id',
-            'directus_files_id.width',
-            'directus_files_id.height'
-          ]
-        }
-      ]
-    }
-  ];
-	
+	let queryFilters = {};
+
+	if (streetFilters.length > 0) {
+		queryFilters.street = {
+			_in: streetFilters
+		};
+	}
+
+	if (nameFilters.length > 0) {
+		queryFilters.person = {
+			_or: [
+				{
+					first_name: {
+						_in: nameFilters
+					}
+				},
+				{
+					last_name: {
+						_in: nameFilters
+					}
+				}
+			]
+		};
+	}
+
+	const queryFields = [
+		'id',
+		'street',
+		'house_number',
+		'floor',
+		'addition',
+		'map',
+		{ person: ['first_name', 'last_name'] },
+		{
+			poster: [
+				'id',
+				{ covers: ['directus_files_id.id', 'directus_files_id.width', 'directus_files_id.height'] }
+			]
+		}
+	];
+
 	try {
 		const directus = getDirectusInstance(fetch);
 		return {
@@ -56,7 +61,12 @@ export async function load({ fetch, url }) {
 					fields: queryFields,
 					sort: ['street', 'house_number', 'addition', 'floor']
 				})
-			)
+			),
+      streets: await directus.request(
+        readItems('atlas_address', {
+          fields: ['street']
+        })
+      )
 		};
 	} catch (error) {
 		console.error(error);

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -20,11 +20,11 @@
 		display: grid;
 		grid-template-areas:
 			'map map'
-      'filter header'
+      'filter posters'
 			'filter posters';
 	}
 
-	:global(main.posters-overview > section) {
+	:global(main.posters-overview > section.map) {
 		grid-area: map; 
 	}
 
@@ -32,11 +32,7 @@
 		grid-area: filter;
 	}
 
-	:global(main.posters-overview > header) {
-		grid-area: header;
-	}
-
-	:global(main.posters-overview > ul) {
+	:global(main.posters-overview > section.overview) {
 		grid-area: posters;
 	}
 </style>

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -6,11 +6,15 @@
 	let { data } = $props();
 	let mapAddresses = $derived(data.addresses.filter((address) => address.map?.coordinates));
 	let filterOpen = $state(false);
+
+	let streets = $derived(
+		Array.from(new Set(data.streets.map((item) => item.street.trim()))).sort()
+	);
 </script>
 
 <main class="posters-overview">
 	<Map {mapAddresses} />
-	<SideFilter bind:filterOpen />
+	<SideFilter bind:filterOpen {streets} />
 	<PostersOverview addresses={data.addresses} {filterOpen} />
 </main>
 
@@ -20,13 +24,13 @@
 		display: grid;
 		grid-template-areas:
 			'map map'
-      'filter posters'
+			'filter posters'
 			'filter posters';
 		min-height: 100vh;
 	}
 
 	:global(main.posters-overview > section.map) {
-		grid-area: map; 
+		grid-area: map;
 	}
 
 	:global(main.posters-overview > aside) {

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -1,18 +1,42 @@
 <script>
 	import PostersOverview from '$lib/organisms/PostersOverview.svelte';
 	import Map from '$lib/organisms/Map.svelte';
+	import SideFilter from '$lib/organisms/SideFilter.svelte';
 
 	let { data } = $props();
 	let mapAddresses = $derived(data.addresses.filter((address) => address.map?.coordinates));
+	let filterOpen = $state(false);
 </script>
 
-<main>
+<main class="posters-overview">
 	<Map {mapAddresses} />
+	<SideFilter bind:filterOpen />
+	<PostersOverview addresses={data.addresses} {filterOpen} />
 </main>
 
 <style>
-  main {
-    margin: 0 auto;
-    padding: var(--spacing-sm) var(--page-padding);
-  }
+	main {
+		margin: 0 auto;
+		display: grid;
+		grid-template-areas:
+			'map map'
+      'filter header'
+			'filter posters';
+	}
+
+	:global(main.posters-overview > section) {
+		grid-area: map; 
+	}
+
+	:global(main.posters-overview > aside) {
+		grid-area: filter;
+	}
+
+	:global(main.posters-overview > header) {
+		grid-area: header;
+	}
+
+	:global(main.posters-overview > ul) {
+		grid-area: posters;
+	}
 </style>

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -22,6 +22,7 @@
 			'map map'
       'filter posters'
 			'filter posters';
+		min-height: 100vh;
 	}
 
 	:global(main.posters-overview > section.map) {

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -1,22 +1,13 @@
 <script>
-  import { onMount } from 'svelte';
-  import PostersOverview from "$lib/organisms/PostersOverview.svelte"
-  import Map from "$lib/organisms/Map.svelte";
-	import { on } from 'svelte/events';
-  
-  let { data } = $props();
-  let mapAddresses = $derived(data.addresses.filter(address => address.map?.coordinates));
-  
-  let javascriptEnabled = $state(false);
+	import PostersOverview from '$lib/organisms/PostersOverview.svelte';
+	import Map from '$lib/organisms/Map.svelte';
 
-  onMount(() => {
-    javascriptEnabled = true;
-  });
+	let { data } = $props();
+	let mapAddresses = $derived(data.addresses.filter((address) => address.map?.coordinates));
 </script>
 
 <main>
-  <Map mapAddresses={mapAddresses} javascriptEnabled={javascriptEnabled}/>
-  <PostersOverview addresses={data.addresses} />
+	<Map {mapAddresses} />
 </main>
 
 <style>


### PR DESCRIPTION
## What does this change?

Resolves issues 
- #214
- #215 
- #216

Created a basic working version of the new filter system, which uses checkboxes to allow the user to filter for multiple streets and/or names at a time. Changed the fetch request accordingly. Deprecated old code will be cleaned up in a future PR, along with fixing the hover state which is currently broken, and making the element responsive.

Also fixed a bug where not all streets would be displayed in the filter list if a filter was currently applied.

Additionally, I made sure that the Map component uses the improved `javascriptEnabled` import to check for JS availbility.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

Before:
![image](https://github.com/user-attachments/assets/c3efaa96-f132-43e7-b44b-2140d726b8f1)

After:
![image](https://github.com/user-attachments/assets/7df8fec8-4ba8-4a5d-b6fc-c37439f64cab)

## How to review

Check the components from smallest to largest; first see Checkbox.svelte, then see FilterSection.svelte, PostersOverview.svelte & SideFilter.svelte, and finally +page.svelte.

Then, see how the changes to the fetch are applied in +page.js.

Finally, see the misc changes made to Map.svelte.