### PR TITLE
Responsive and working side filter component

### DIFF
--- a/src/lib/molecules/Nav.svelte
+++ b/src/lib/molecules/Nav.svelte
@@ -13,7 +13,7 @@
 </script>
 
 <nav class={{"js-enabled": javascript.enabled}}>
-  <Button buttonClass={$css("menu-button")} onclick={toggleMenu} class={{"hidden": !javascript.enabled}}>
+  <Button buttonClass={$css("menu-button")} onclick={toggleMenu} class={{"hidden": !javascript.enabled, "highlight": true}}>
     Menu
   </Button>
   <ul class={{"is-open": isOpen}}>
@@ -53,7 +53,6 @@
     background-color: var(--white);
     padding: 0 0 var(--spacing-sm) 0;
     gap: var(--spacing-sm);
-    z-index: 100;
     text-align: center;
     border-bottom: 1px solid var(--neutral-400);
     font-weight: var(--font-weight-bold);

--- a/src/lib/molecules/Nav.svelte
+++ b/src/lib/molecules/Nav.svelte
@@ -1,23 +1,19 @@
 <script>
 	import Button from "$lib/atoms/Button.svelte";
+  import { javascript } from "$lib/utils/javascriptEnabled.svelte.js";
   import { onMount } from 'svelte';
 
 	let { children } = $props()
 
-  let jsEnabled = $state(false);
   let isOpen = $state(false);
-
-  onMount(() => {
-    jsEnabled = true;
-  });
 
   function toggleMenu() {
     isOpen = !isOpen;
   }
 </script>
 
-<nav class={{"js-enabled": jsEnabled}}>
-  <Button buttonClass={$css("menu-button")} onclick={toggleMenu}>
+<nav class={{"js-enabled": javascript.enabled}}>
+  <Button buttonClass={$css("menu-button")} onclick={toggleMenu} class={{"hidden": !javascript.enabled}}>
     Menu
   </Button>
   <ul class={{"is-open": isOpen}}>

--- a/src/lib/organisms/Header.svelte
+++ b/src/lib/organisms/Header.svelte
@@ -37,7 +37,7 @@
     justify-content: space-between;
     position: fixed;
 		top:0;
-		z-index:100;
+		z-index: 200;
 	}
 
 	img {

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -72,18 +72,18 @@
 <style>
     @import 'leaflet/dist/leaflet.css';
     section {
-      display:none;
+      display: none;
       width: calc(100% + 2* var(--page-padding));
       position: relative;
-      z-index:1;
-      border-bottom:5px solid var(--blue-300);
+      z-index: 1;
+      border-bottom: 5px solid var(--blue-300);
     }
 
     section.js-enabled {
-      display:block;
+      display: block;
     }
 
     div {
-      height:60vh;
+      height: 60vh;
     }
 </style>

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -73,7 +73,7 @@
     @import 'leaflet/dist/leaflet.css';
     section {
       display: none;
-      width: calc(100% + 2* var(--page-padding));
+      width: 100%;
       position: relative;
       z-index: 1;
       border-bottom: 5px solid var(--blue-300);

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -66,6 +66,10 @@
 		padding-top: var(--spacing-lg);
 	}
 
+  section {
+    padding: 0 var(--page-padding);
+  }
+
 	@media screen and (min-width: 800px) {
 		div:global(:has(.landscape)) {
 			grid-column: span 2;

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -7,13 +7,12 @@
 	import { fade } from 'svelte/transition';
 	import { cubicOut } from 'svelte/easing';
 
-	let { addresses = [], filterOpen } = $props();
+	let { addresses = []} = $props();
 </script>
 
 <section class="overview">
 	<header>
 		<PostersTitle length={addresses.length} />
-		<Button onclick={() => (filterOpen = !filterOpen)} class={$css('filter-button')}>Filters</Button>
 	</header>
 
 	{#await addresses}
@@ -66,10 +65,6 @@
 	p {
 		padding-top: var(--spacing-lg);
 	}
-
-  .filter-button {
-    display: block !important;
-  }
 
 	@media screen and (min-width: 800px) {
 		div:global(:has(.landscape)) {

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -57,7 +57,7 @@
 	}
 	ul {
 		display: grid;
-		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+		grid-template-columns: repeat(auto-fit, minmax(300px, 100%), 1fr);
 		gap: var(--spacing-sm);
 		padding-top: var(--spacing-sm);
 	}

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -66,7 +66,7 @@
 		padding-top: var(--spacing-lg);
 	}
 
-  section {
+  section.overview {
     padding: 0 var(--page-padding);
   }
 
@@ -86,12 +86,8 @@
 			padding-top: var(--spacing-md);
 		}
 
-    section {
+    section.overview {
       padding: 0 var(--spacing-md);
-    }
-
-    .filter-button {
-      display: none !important;
     }
 	}
 </style>

--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -57,7 +57,7 @@
 	}
 	ul {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 100%), 1fr);
+		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
 		gap: var(--spacing-sm);
 		padding-top: var(--spacing-sm);
 	}

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -19,17 +19,14 @@
 		).sort() // Sort alphabetically
 	);
 
-	let form;
-
-	function filterHandler(event) {
-		form.requestSubmit();
-	}
+	let formAside;
+	let formDetails;
 </script>
 
 <!-- IF JS ENABLED SHOW ASIDE VERSION -->
 <aside class={{ hidden: !javascript.enabled, open: filterOpen }}>
 	<h3>Filters</h3>
-	<form bind:this={form} action="/adressen" data-sveltekit-noscroll>
+	<form bind:this={formAside} action="/adressen" data-sveltekit-noscroll>
 		<Button
 			class={{ 'sr-only': javascript.enabled, highlight: true }}
 			buttonClass={$css('show-on-focus')}
@@ -38,12 +35,12 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection title="Straat" name="s" items={streets} onchange={filterHandler} />
+			<FilterSection title="Straat" name="s" items={streets} onchange={() => formAside.requestSubmit()} />
 			<FilterSection
 				title="Naam"
 				name="n"
 				items={['Jacob', 'Vries', 'Kreveld']}
-				onchange={filterHandler}
+				onchange={() => formAside.requestSubmit()}
 			/>
 			<!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
 			<!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->
@@ -62,7 +59,7 @@
 	<summary>
 		<h3>Filters</h3>
 	</summary>
-	<form bind:this={form} action="/adressen" data-sveltekit-noscroll>
+	<form bind:this={formDetails} action="/adressen" data-sveltekit-noscroll>
 		<Button
 			class={{ 'sr-only': javascript.enabled, highlight: true }}
 			buttonClass={$css('show-on-focus')}
@@ -71,12 +68,12 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection title="Straat" name="s" items={streets} onchange={filterHandler} />
+			<FilterSection title="Straat" name="s" items={streets} onchange={() => formDetails.requestSubmit()} />
 			<FilterSection
 				title="Naam"
 				name="n"
 				items={['Jacob', 'Vries', 'Kreveld']}
-				onchange={filterHandler}
+				onchange={() => formDetails.requestSubmit()}
 			/>
 			<!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
 			<!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->
@@ -92,7 +89,7 @@
 		left: 0;
 		background-color: var(--white);
 		padding: var(--spacing-md);
-		height: 100vh;
+    height: calc(100vh - 6rem);
 		width: 100vw;
 		overflow-y: auto;
 		z-index: 100;
@@ -144,10 +141,11 @@
 	@media screen and (min-width: 460px) {
 		aside {
 			position: sticky;
-			top: 6rem;
 			box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
-			padding: var(--spacing-md);
 			height: calc(100vh - 6rem);
+      width: 20rem;
+      transform: translateX(0);
+      z-index: 0;
 		}
 	}
 </style>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -6,6 +6,8 @@
 
 	let { streets } = $props();
 
+  let filterOpen = $state(false);
+
 	// Derive the list of streets from the posters
 	let streetsList = $derived(
 		Array.from(
@@ -17,15 +19,16 @@
 		).sort() // Sort alphabetically
 	);
 
-  let form;
+	let form;
 
-  function filterHandler(event) {
-    form.requestSubmit();
-  }
+	function filterHandler(event) {
+		form.requestSubmit();
+	}
 </script>
 
-<aside>
-  <h3>Filters</h3>
+<!-- IF JS ENABLED SHOW ASIDE VERSION -->
+<aside class={{ hidden: !javascript.enabled, open: filterOpen }}>
+	<h3>Filters</h3>
 	<form bind:this={form} action="/adressen" data-sveltekit-noscroll>
 		<Button
 			class={{ 'sr-only': javascript.enabled, highlight: true }}
@@ -36,22 +39,82 @@
 		</Button>
 		<div>
 			<FilterSection title="Straat" name="s" items={streets} onchange={filterHandler} />
-			<FilterSection title="Naam" name="n" items={['Jacob', 'Vries', 'Kreveld']} onchange={filterHandler} />
-      <!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
-      <!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->
+			<FilterSection
+				title="Naam"
+				name="n"
+				items={['Jacob', 'Vries', 'Kreveld']}
+				onchange={filterHandler}
+			/>
+			<!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
+			<!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->
 		</div>
 	</form>
 </aside>
 
+<Button
+	onclick={() => (filterOpen = !filterOpen)}
+	class="highlight"
+	buttonClass={$css('filter-button')}>Filters</Button
+>
+
+<!-- IF JS DISABLED SHOW DETAILS VERSION -->
+<details class={{ hidden: javascript.enabled }}>
+	<summary>
+		<h3>Filters</h3>
+	</summary>
+	<form bind:this={form} action="/adressen" data-sveltekit-noscroll>
+		<Button
+			class={{ 'sr-only': javascript.enabled, highlight: true }}
+			buttonClass={$css('show-on-focus')}
+			type="submit"
+		>
+			Toepassen
+		</Button>
+		<div>
+			<FilterSection title="Straat" name="s" items={streets} onchange={filterHandler} />
+			<FilterSection
+				title="Naam"
+				name="n"
+				items={['Jacob', 'Vries', 'Kreveld']}
+				onchange={filterHandler}
+			/>
+			<!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
+			<!-- <FilterSection title="Stolpesteiner" name="p" items={['Stolpesteiner']} onchange={filterHandler} /> -->
+		</div>
+	</form>
+</details>
+
 <style>
 	aside {
-    position: sticky;
-    top: 6rem;
+		display: block;
+		position: fixed;
+		top: 6rem;
+		left: 0;
 		background-color: var(--white);
-		box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
 		padding: var(--spacing-md);
-    height: calc(100vh - 6rem);
-    overflow-y: auto;
+		height: 100vh;
+		width: 100vw;
+		overflow-y: auto;
+		z-index: 100;
+		transform: translateX(-100%);
+		transition: transform 0.3s ease-in-out;
+	}
+
+	.filter-button {
+		position: fixed;
+		top: calc(6rem + var(--spacing-md));
+		left: var(--page-padding);
+		z-index: 100;
+		transition: all 0.3s ease-in-out !important;
+	}
+
+	aside.open + .filter-button {
+    /* Move button to right of screen */
+		transform: translateX(calc(100vw - 100% - var(--page-padding)*2));
+	}
+
+	aside.open {
+		transform: translateX(0);
 	}
 
 	form {
@@ -76,5 +139,15 @@
 		clip: auto;
 		white-space: normal;
 		border-width: 0;
+	}
+
+	@media screen and (min-width: 460px) {
+		aside {
+			position: sticky;
+			top: 6rem;
+			box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
+			padding: var(--spacing-md);
+			height: calc(100vh - 6rem);
+		}
 	}
 </style>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -148,7 +148,7 @@
 		border-width: 0;
 	}
 
-	@media screen and (min-width: 460px) {
+	@media screen and (min-width: 800px) {
 		aside {
 			position: sticky;
 			box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -6,7 +6,7 @@
 
 	let { streets } = $props();
 
-  let filterOpen = $state(false);
+	let filterOpen = $state(false);
 
 	// Derive the list of streets from the posters
 	let streetsList = $derived(
@@ -35,7 +35,12 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection title="Straat" name="s" items={streets} onchange={() => formAside.requestSubmit()} />
+			<FilterSection
+				title="Straat"
+				name="s"
+				items={streets}
+				onchange={() => formAside.requestSubmit()}
+			/>
 			<FilterSection
 				title="Naam"
 				name="n"
@@ -68,7 +73,12 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection title="Straat" name="s" items={streets} onchange={() => formDetails.requestSubmit()} />
+			<FilterSection
+				title="Straat"
+				name="s"
+				items={streets}
+				onchange={() => formDetails.requestSubmit()}
+			/>
 			<FilterSection
 				title="Naam"
 				name="n"
@@ -89,7 +99,7 @@
 		left: 0;
 		background-color: var(--white);
 		padding: var(--spacing-md);
-    height: calc(100vh - 6rem);
+		height: calc(100vh - 6rem);
 		width: 100vw;
 		overflow-y: auto;
 		z-index: 100;
@@ -106,8 +116,8 @@
 	}
 
 	aside.open + .filter-button {
-    /* Move button to right of screen */
-		transform: translateX(calc(100vw - 100% - var(--page-padding)*2));
+		/* Move button to right of screen */
+		transform: translateX(calc(100vw - 100% - var(--page-padding) * 2));
 	}
 
 	aside.open {
@@ -143,9 +153,13 @@
 			position: sticky;
 			box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
 			height: calc(100vh - 6rem);
-      width: 20rem;
-      transform: translateX(0);
-      z-index: 0;
+			width: 20rem;
+			transform: translateX(0);
+			z-index: 0;
+		}
+
+		.filter-button {
+			display: none !important;
 		}
 	}
 </style>

--- a/src/routes/adressen/+page.js
+++ b/src/routes/adressen/+page.js
@@ -2,23 +2,25 @@ import getDirectusInstance from '$lib/directus';
 import { readItems } from '@directus/sdk';
 
 export async function load({ fetch, url }) {
-
+  // Initialize the filters
   let streetFilters = [];
   let nameFilters = [];
+  let queryFilters = {};
+
   // Extract the values by key and add them to their respective arrays
   url.searchParams.forEach((value, key) => {
     (key == 's') && (streetFilters.push(value));
     (key == 'n') && (nameFilters.push(value));
   });
 
-	let queryFilters = {};
-
+  // Add the street filters to the query
 	if (streetFilters.length > 0) {
 		queryFilters.street = {
 			_in: streetFilters
 		};
 	}
 
+  // Add the name filters to the query  
 	if (nameFilters.length > 0) {
 		queryFilters.person = {
 			_or: [
@@ -36,6 +38,7 @@ export async function load({ fetch, url }) {
 		};
 	}
 
+  // Define the fields to be fetched
 	const queryFields = [
 		'id',
 		'street',
@@ -52,6 +55,7 @@ export async function load({ fetch, url }) {
 		}
 	];
 
+  // Get the addresses
 	try {
 		const directus = getDirectusInstance(fetch);
 		return {

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -18,25 +18,32 @@
 </main>
 
 <style>
-	main {
-		margin: 0 auto;
-		display: grid;
-		grid-template-areas:
-			'map map'
-			'filter posters'
-			'filter posters';
-		min-height: 100vh;
-	}
+  main {
+    margin: 0 auto;
+    padding: var(--spacing-sm) var(--page-padding) 0;
+  }
 
-	:global(main.posters-overview > section.map) {
-		grid-area: map;
-	}
+	@media screen and (min-width: 460px) {
+		main {
+			margin: 0 auto;
+			display: grid;
+			grid-template-areas:
+				'map map'
+				'filter posters'
+				'filter posters';
+			min-height: 100vh;
+		}
 
-	:global(main.posters-overview > aside) {
-		grid-area: filter;
-	}
+		main :global(section.map) {
+			grid-area: map;
+		}
 
-	:global(main.posters-overview > section.overview) {
-		grid-area: posters;
+		main :global(aside) {
+			grid-area: filter;
+		}
+
+		main :global(section.overview) {
+			grid-area: posters;
+		}
 	}
 </style>

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -30,6 +30,7 @@
 				'map map'
 				'filter posters'
 				'filter posters';
+      grid-template-columns: auto 1fr;
 			min-height: 100vh;
 		}
 

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -20,7 +20,6 @@
 <style>
   main {
     margin: 0 auto;
-    padding: var(--spacing-sm) var(--page-padding) 0;
   }
 
 	@media screen and (min-width: 460px) {

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -5,7 +5,6 @@
 
 	let { data } = $props();
 	let mapAddresses = $derived(data.addresses.filter((address) => address.map?.coordinates));
-	let filterOpen = $state(false);
 
 	let streets = $derived(
 		Array.from(new Set(data.streets.map((item) => item.street.trim()))).sort()
@@ -14,8 +13,8 @@
 
 <main class="posters-overview">
 	<Map {mapAddresses} />
-	<SideFilter bind:filterOpen {streets} />
-	<PostersOverview addresses={data.addresses} {filterOpen} />
+	<SideFilter {streets} />
+	<PostersOverview addresses={data.addresses} />
 </main>
 
 <style>

--- a/static/global.css
+++ b/static/global.css
@@ -188,6 +188,10 @@ div.query-container {
 	border-width: 0;
 }
 
+.hidden {
+  display: none !important;
+}
+
 .focus-ring {
 	transition: outline 0.15s ease-in-out;
 	outline: 0px solid var(--brown-400);


### PR DESCRIPTION
## What does this change?

Resolves issues:
- #220 
- #223

Also laid groundwork for #221, but this still needs some work.

Created a mobile layout for the sidebar filter, where it can be collapsed and opened with a button. Laid the groundwork for having a details/summary version rendered when javascript is not enabled, to preserve PE, however this version still needs to be styled.

Also made sure that the filter actually works once again, and submits when the onChange event is fired from one of the checkboxes.

Refactored Nav component to use new javascript-check import and changed styling of menu button on mobile slightly to be more consistent across the website. Also fixed a z-index issue with nav and header on mobile.

Also added some comments to the load function for the addresses page, along with adding a "hidden" utility class, which should simplify some "hide element if js is enabled" cases.

NOTE: Some bugs were found, but these have been added to the project board as tasks and will be fixed in the future. Styling on the filter button could also use some work. The code should also be refactored sometime in the future, as it is currently quite verbose.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

Before:
![image](https://github.com/user-attachments/assets/889cb41a-b659-4e6e-9e86-00f50be2a0dd)

After:

https://github.com/user-attachments/assets/7b6c2e35-e92b-433b-b14a-e656337c9c31


## How to review

First, review `+page.svelte`, `SideFilter.svelte` and `PostersOverview.svelte` in order. Then review `Nav.svelte`, `Header.svelte`, `Map.svelte`, `+page.js` and `global.css` to see miscellaneous changes.
