### PR TITLE
feat: Filter styling and search fields

### DIFF
--- a/src/lib/atoms/Checkbox.svelte
+++ b/src/lib/atoms/Checkbox.svelte
@@ -5,7 +5,6 @@
 		children,
 		inputClass = '',
 		labelClass = '',
-		checked = '',
 		value = 'on',
     onchange,
     ...rest

--- a/src/lib/atoms/TextInput.svelte
+++ b/src/lib/atoms/TextInput.svelte
@@ -7,13 +7,14 @@
     children, 
     inputClass = "", 
     labelClass = "",
+    value = $bindable(""),
     ...rest
   } = $props();
 </script>
 
 <!-- Give label a sr-only class if (sronly) is truthy -->
 <label for={id} class={[sronly && "sr-only", labelClass]} >{@render children()}</label>
-<input {id} {type} {placeholder} class="no-focus {inputClass}" name={id} {...rest} />
+<input bind:value {id} {type} {placeholder} class="no-focus {inputClass}" name={id} {...rest} />
 
 <style>
 	input {

--- a/src/lib/molecules/FilterSection.svelte
+++ b/src/lib/molecules/FilterSection.svelte
@@ -21,13 +21,13 @@
   fieldset {
     border: none;
     padding: 0;
-    margin: var(--spacing-md) 0;
+    margin: var(--spacing-lg) 0;
   }
 
   legend {
-    font-size: var(--font-size-sm);
+    font-size: var(--font-size-lg);
     font-weight: var(--font-weight-bold);
-    margin-bottom: var(--spacing-xs);
+    margin-bottom: var(--spacing-sm);
   }
 
   ul {

--- a/src/lib/molecules/FilterSectionList.svelte
+++ b/src/lib/molecules/FilterSectionList.svelte
@@ -1,7 +1,19 @@
 <script>
   import Checkbox from '$lib/atoms/Checkbox.svelte';
-
+  import { page } from '$app/state';
   let { title, items, onchange, name } = $props();
+
+  let activeValues = $state([]);
+
+  // Extract active values from the URL and add them to the activeValues array
+  page.url.searchParams.forEach((value, key) => {
+    (key == name) && (activeValues.push(value));
+  });
+
+  function removeValueHandler(event) {
+    activeValues = activeValues.filter(value => value !== event.target.id);
+    onchange();
+  }
 </script>
 
 <fieldset>
@@ -9,7 +21,7 @@
   <ul>
     {#each items as item}
       <li>
-        <Checkbox id={item} label={item} {name} {onchange}>
+        <Checkbox id={item} label={item} {name} onchange={removeValueHandler} checked={activeValues.includes(item)}>
           {item}
         </Checkbox>
       </li>

--- a/src/lib/molecules/FilterSectionSearch.svelte
+++ b/src/lib/molecules/FilterSectionSearch.svelte
@@ -1,0 +1,77 @@
+<script>
+  import TextInput from '$lib/atoms/TextInput.svelte';
+  import Button from '$lib/atoms/Button.svelte';
+  import Checkbox from '$lib/atoms/Checkbox.svelte';
+  import { page } from '$app/state';
+  let { title, onchange, name } = $props();
+
+  let enteredValue = $state("");
+  let activeValues = $state([]);
+
+  // Extract active names from the URL and add them to the activeNames array
+  page.url.searchParams.forEach((value, key) => {
+    (key == name) && (activeValues.push(value));
+  });
+
+  function addValueHandler() {
+    if (enteredValue.length > 0) {
+      activeValues.push(enteredValue);
+      enteredValue = "";
+    }
+  }
+
+  function removeValueHandler(event) {
+    activeValues = activeValues.filter(value => value !== event.target.id);
+    onchange();
+  }
+</script>
+
+<fieldset>
+  <legend>Zoeken op {title}</legend>
+  <div>
+    <TextInput bind:value={enteredValue} id={name} placeholder="Jacob..." sronly={true} name="">Zoeken op {title}</TextInput>
+    <Button  class="highlight" onclick={addValueHandler} buttonClass={$css('add-value')}>+</Button>
+  </div>
+  <ul>
+    {#each activeValues as activeValue}
+      <li>
+        <Checkbox id={activeValue} label={activeValue} {name} onchange={removeValueHandler} checked="true">
+          {activeValue}
+        </Checkbox>
+      </li>
+    {/each}
+  </ul>
+</fieldset>
+
+<style>
+  fieldset {
+    border: none;
+    padding: 0;
+    margin: var(--spacing-lg) 0;
+  }
+
+  legend {
+    font-size: var(--font-size-lg);
+    font-weight: var(--font-weight-bold);
+    margin-bottom: var(--spacing-sm);
+  }
+
+  div {
+    display: flex;
+    gap: var(--spacing-xs);
+    max-width: 100%;
+    margin-bottom: var(--spacing-sm);
+  }
+
+  ul {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-xs);
+    list-style: none;
+  }
+
+  .add-value {
+    /* color: var(--blue-900) !important; */
+    border: 2px solid var(--blue-100) !important;
+  }
+</style>

--- a/src/lib/organisms/Header.svelte
+++ b/src/lib/organisms/Header.svelte
@@ -29,7 +29,8 @@
 	header {
 		display: flex;
 		width: 100%;
-		padding: var(--spacing-sm) var(--page-padding);
+    /* Lining up with the side filter */
+		padding: var(--spacing-sm) calc(var(--spacing-sm) + 0.2rem);
 		margin-bottom: var(--spacing-sm);
 		background-color: #fff;
 		box-shadow: 0 -20px 10px 20px rgba(0, 0, 0, 0.303);

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -97,8 +97,9 @@
 		position: fixed;
 		top: 6rem;
 		left: 0;
-		background-color: var(--white);
-		padding: var(--spacing-md);
+		background-color: var(--blue-500);
+    color: var(--white);
+		padding: var(--spacing-lg) var(--spacing-md);
 		height: calc(100vh - 6rem);
 		width: 100vw;
 		overflow-y: auto;
@@ -106,6 +107,12 @@
 		transform: translateX(-100%);
 		transition: transform 0.3s ease-in-out;
 	}
+
+  aside h3 {
+    color: var(--white);
+    font-size: var(--font-size-xxl);
+    font-weight: var(--font-weight-regular);
+  }
 
 	.filter-button {
 		position: fixed;
@@ -151,7 +158,6 @@
 	@media screen and (min-width: 800px) {
 		aside {
 			position: sticky;
-			box-shadow: -20px 0px 10px 20px rgba(0, 0, 0, 0.303);
 			height: calc(100vh - 6rem);
 			width: 20rem;
 			transform: translateX(0);

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -1,5 +1,6 @@
 <script>
-	import FilterSection from '$lib/molecules/FilterSection.svelte';
+	import FilterSectionList from '$lib/molecules/FilterSectionList.svelte';
+  import FilterSectionSearch from '$lib/molecules/FilterSectionSearch.svelte';
 	import Button from '$lib/atoms/Button.svelte';
 	import { javascript } from '$lib/utils/javascriptEnabled.svelte.js';
 	import { page } from '$app/state';
@@ -35,16 +36,15 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection
+			<FilterSectionList
 				title="Straat"
 				name="s"
 				items={streets}
 				onchange={() => formAside.requestSubmit()}
 			/>
-			<FilterSection
+			<FilterSectionSearch
 				title="Naam"
 				name="n"
-				items={['Jacob', 'Vries', 'Kreveld']}
 				onchange={() => formAside.requestSubmit()}
 			/>
 			<!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->
@@ -73,16 +73,15 @@
 			Toepassen
 		</Button>
 		<div>
-			<FilterSection
+			<FilterSectionList
 				title="Straat"
 				name="s"
 				items={streets}
 				onchange={() => formDetails.requestSubmit()}
 			/>
-			<FilterSection
+			<FilterSectionSearch
 				title="Naam"
 				name="n"
-				items={['Jacob', 'Vries', 'Kreveld']}
 				onchange={() => formDetails.requestSubmit()}
 			/>
 			<!-- <FilterSection title="Thema" name="t" items={['Thema 1', 'Thema 2', 'Thema 3', 'Thema 4']} onchange={filterHandler} /> -->

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -6,6 +6,7 @@
 	let { data } = $props();
 	let mapAddresses = $derived(data.addresses.filter((address) => address.map?.coordinates));
 
+  // Parse the streets list
 	let streets = $derived(
 		Array.from(new Set(data.streets.map((item) => item.street.trim()))).sort()
 	);
@@ -27,8 +28,7 @@
 			margin: 0 auto;
 			display: grid;
 			grid-template-areas:
-				'map map'
-				'filter posters'
+				'filter map'
 				'filter posters';
       grid-template-columns: auto 1fr;
 			min-height: 100vh;


### PR DESCRIPTION
## What does this change?

Resolves issues
- #227 

Created a FilterSection variant where there is a search bar which the user can add custom entries to the list with. This way users can search for names using a search bar but can also have several of these names active at a time.

Also improved some of the filter styling to better preserve visual hierarchy.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

Before:
![image](https://github.com/user-attachments/assets/56f7008a-0075-42fd-b961-43e6d970696a)

After

https://github.com/user-attachments/assets/4b87778c-9cb9-49f2-a948-04b8b50c3020