### PR TITLE
Feature 230 improve detailpage

### DIFF
--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -54,26 +54,47 @@
 
 	ol {
 		width: 100%;
+		list-style: none;
 		display: flex;
 		flex-direction: row;
 		align-items:start;
 		gap: var(--spacing-sm);
+
+		/* SCROLLING */
 		overflow-x: auto;
 		scroll-snap-type: x mandatory;		
 		scroll-behavior: smooth;
 		-webkit-overflow-scrolling: touch;
+
+		/* SCROLLBAR */
+		scrollbar-width: 0;
+
+		&::-webkit-scrollbar {
+			width: 0;
+		}
+
+		&::-webkit-scrollbar-track {
+			background: transparent;
+		}
+
+		&::-webkit-scrollbar-thumb {
+			background: transparent;
+			border: none;
+		}
 	}
 
 	ol li {
-		flex: 0 0 80%;
-		min-width: 16rem;
+		/* flex: 0 0 1; */
+		width: fit-content;
+		height: 100% !important;
+		max-width: auto;
 		scroll-snap-align: start;
 	}
 
-	/* ol li :global(img) {
-		height: 100%;
-		width: 80%;
-	} */
+	ol li :global(img) {
+		height: 100% !important;
+		width: auto;
+	}
 
 	article {
 		display: flex;

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -34,9 +34,9 @@
 <style>
 	main {
 		display: flex;
-		max-height: calc(100vh - 6rem); /* 6rem = padding top */
+		flex-wrap: wrap;
 		padding: var(--spacing-md);
-		gap: var(--spacing-xl);
+		gap: var(--spacing-md);
 	}
 
 	h1 {
@@ -87,20 +87,35 @@
 
 	ol li {
 		width: fit-content;
-		height: 100% !important;
 		max-width: auto;
+		min-width: 16rem;
 		scroll-snap-align: start;
 	}
 
-	ol li :global(img) {
-		height: 100% !important;
-		width: auto;
-	}
 
 	article {
 		display: flex;
 		flex-direction: column;
 		width: 100%;
 		padding:var(--spacing-md) 0;
+	}
+
+	@media screen and (min-width: 800px) {
+		main {
+			flex-wrap: nowrap;
+			max-height: calc(100vh - 6rem); /* 6rem = padding top */
+			gap: var(--spacing-xl);
+		}
+
+		ol li {
+			width: 100%;
+			height: 100% !important;
+			min-width: unset;
+		}
+
+		ol li :global(img) {
+			height: 100% !important;
+			width: auto;	
+		}
 	}
 </style>

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -24,9 +24,9 @@
 		<h2>Personen op dit adres</h2>
 	
 		<ul>
-		{#each person as person}
-				<li>{person.first_name} {person.last_name}</li>
-		{/each}
+			{#each person as person}
+					<li>{person.first_name} {person.last_name}</li>
+			{/each}
 		</ul>
 	</article>
 </main>
@@ -34,14 +34,14 @@
 <style>
 	main {
 		display: flex;
-		background-color: aqua;
 		max-height: calc(100vh - 6rem); /* 6rem = padding top */
 		padding: var(--spacing-md);
-		gap: var(--spacing-sm);
+		gap: var(--spacing-xl);
 	}
 
 	h1 {
-		padding:var(--spacing-md) 0;
+		/* padding:var(--spacing-md) 0; */
+		font-size: var(--font-size-title-md);
 	}
 
 	h2 {
@@ -59,8 +59,10 @@
 		flex-direction: row;
 		align-items:start;
 		gap: var(--spacing-sm);
+		align-items: start;
 
 		/* SCROLLING */
+		overflow-y: hidden;
 		overflow-x: auto;
 		scroll-snap-type: x mandatory;		
 		scroll-behavior: smooth;
@@ -84,7 +86,6 @@
 	}
 
 	ol li {
-		/* flex: 0 0 1; */
 		width: fit-content;
 		height: 100% !important;
 		max-width: auto;
@@ -98,10 +99,8 @@
 
 	article {
 		display: flex;
-		justify-content: center;
-		align-items: center;
 		flex-direction: column;
-		background-color: goldenrod;
 		width: 100%;
+		padding:var(--spacing-md) 0;
 	}
 </style>

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -6,35 +6,43 @@
 </script>
 
 <main>
-	<h1>{street} {house_number} {addition} {floor}</h1>
-
-	{#each poster.covers as image}
-		<DirectusImage
-			imageId={image.directus_files_id.id}
-			width={image.directus_files_id.width}
-			height={image.directus_files_id.height}
-			alt="Gedenkposter van {street} {house_number} {addition} {floor}}"
-		/>
-	{/each}
-
-	<h2>Personen op dit adres</h2>
-
-	<ul>
-	{#each person as person}
-			<li>{person.first_name} {person.last_name}</li>
-	{/each}
-	</ul>
+	<ol>
+		{#each poster.covers as image}
+			<li>
+				<DirectusImage
+					imageId={image.directus_files_id.id}
+					width={image.directus_files_id.width}
+					height={image.directus_files_id.height}
+					alt="Gedenkposter van {street} {house_number} {addition} {floor}}"
+				/>
+			</li>
+		{/each}
+	</ol>
+	
+	<article>
+		<h1>{street} {house_number} {addition} {floor}</h1>
+		<h2>Personen op dit adres</h2>
+	
+		<ul>
+		{#each person as person}
+				<li>{person.first_name} {person.last_name}</li>
+		{/each}
+		</ul>
+	</article>
 </main>
 
 <style>
 	main {
-		padding:var(--spacing-md);
+		display: flex;
+		background-color: aqua;
+		max-height: calc(100vh - 6rem); /* 6rem = padding top */
+		padding: var(--spacing-md);
+		gap: var(--spacing-sm);
 	}
 
 	h1 {
 		padding:var(--spacing-md) 0;
 	}
-
 
 	h2 {
 		margin:var(--spacing-md) 0 var(--spacing-xs);
@@ -42,5 +50,37 @@
 
 	ul {
 		list-style: none;
+	}
+
+	ol {
+		width: 100%;
+		display: flex;
+		flex-direction: row;
+		align-items:start;
+		gap: var(--spacing-sm);
+		overflow-x: auto;
+		scroll-snap-type: x mandatory;		
+		scroll-behavior: smooth;
+		-webkit-overflow-scrolling: touch;
+	}
+
+	ol li {
+		flex: 0 0 80%;
+		min-width: 16rem;
+		scroll-snap-align: start;
+	}
+
+	/* ol li :global(img) {
+		height: 100%;
+		width: 80%;
+	} */
+
+	article {
+		display: flex;
+		justify-content: center;
+		align-items: center;
+		flex-direction: column;
+		background-color: goldenrod;
+		width: 100%;
 	}
 </style>


### PR DESCRIPTION
## What does this change?
The posters at the detail page of the poster where way to big at first. The posters and the writing are now next to each other in the desktop version instead of under eachother. The posters are now a carrousel and are way less big on desktop and mobile.

Resolves issue #230 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->

[livesite](https://livesite.com)

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [x] Browser test 

Browsertest: chrome, firefox, edge (no problems, looks the same)

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
How it looked at first:
![image](https://github.com/user-attachments/assets/8ec39636-73fc-48aa-84a9-9a9ff3a54f46)

How it looks now:
Desktop:
![image](https://github.com/user-attachments/assets/7787e913-1c3f-4c64-ac34-6c5a35cc393e)

Mobile:
![image](https://github.com/user-attachments/assets/d341d768-20ab-45d4-a3df-9b5a0f74d001)


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

code:
src > routes > adressen > [id] > page.svelte

![image](https://github.com/user-attachments/assets/3df58cb5-832b-407f-bcc3-01ce4830029d)

