### PR TITLE
Feature 276 center poster carousel detail page

### DIFF
--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -49,7 +49,6 @@
 		flex-wrap: wrap;
 		padding: var(--spacing-md);
 		gap: var(--spacing-md);
-		height: 100%;
 	}
 
 	h1 {
@@ -134,11 +133,16 @@
 	@media screen and (min-width: 800px) {
 		:global(body) {
 			height: 100vh; /* For big screens */
+			display: flex;
+			align-items: center;
+			/* background-color: aquamarine; */
 		}
 		main {
 			flex-wrap: nowrap;
 			max-height: calc(100vh - 6rem); /* 6rem = padding top */
 			gap: var(--spacing-xl);
+			align-self: center;
+			width: 100%;
 		}
 
 		ol {
@@ -160,7 +164,7 @@
 
 	@media screen and (max-aspect-ratio: 1120/898) {
 		main {
-			background-color: aqua;
+			/* background-color: aqua; */
 			gap: var(--spacing-md);
 		}
 		
@@ -168,7 +172,7 @@
 
 	@container carousel (max-aspect-ratio: 426/620) {
 		li {
-			background-color: aquamarine;
+			/* background-color: aquamarine; */
 			width: 100%;
 		}
 

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -49,6 +49,7 @@
 		flex-wrap: wrap;
 		padding: var(--spacing-md);
 		gap: var(--spacing-md);
+		height: 100%;
 	}
 
 	h1 {
@@ -79,7 +80,6 @@
 		align-items:start;
 		gap: var(--spacing-sm);
 		align-items: start;
-		/* justify-content: center; */
 
 		/* SCROLLING */
 		overflow-y: hidden;
@@ -115,7 +115,7 @@
 	section {
 		display: flex;
 		flex-direction: column;
-		justify-content: space-around;
+		justify-content: space-between;
 		gap: var(--spacing-md);
 		width: 100%;
 	}
@@ -131,9 +131,10 @@
 		border: 5px solid var(--blue-300);
 	}
 
-
-
 	@media screen and (min-width: 800px) {
+		:global(body) {
+			height: 100vh; /* For big screens */
+		}
 		main {
 			flex-wrap: nowrap;
 			max-height: calc(100vh - 6rem); /* 6rem = padding top */

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -79,6 +79,7 @@
 		align-items:start;
 		gap: var(--spacing-sm);
 		align-items: start;
+		/* justify-content: center; */
 
 		/* SCROLLING */
 		overflow-y: hidden;
@@ -105,10 +106,10 @@
 	}
 
 	ol li {
-		width: fit-content;
-		max-width: auto;
+		max-width: fit-content;
 		min-width: 16rem;
 		scroll-snap-align: start;
+		margin: auto;
 	}
 
 	section {

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -158,10 +158,8 @@
 
 		@media screen and (max-aspect-ratio: 1120/898) {
 			main {
-				/* background-color: aqua; */
 				gap: var(--spacing-md);
 			}
-			
 		}
 
 		@media screen and (max-aspect-ratio: 1271/1273) {
@@ -172,11 +170,6 @@
 			.map {
 				max-height: 30vh !important;
 			}
-
-			ol {
-				background-color: blueviolet;
-			}
-			
 		}
 
 		@container carousel (max-aspect-ratio: 426/620) {

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -160,22 +160,37 @@
 			height: 100% !important;
 			width: auto;	
 		}
-	}
 
-	@media screen and (max-aspect-ratio: 1120/898) {
-		main {
-			/* background-color: aqua; */
-			gap: var(--spacing-md);
-		}
-		
-	}
 
-	@container carousel (max-aspect-ratio: 426/620) {
-		li {
-			/* background-color: aquamarine; */
-			width: 100%;
+		@media screen and (max-aspect-ratio: 1120/898) {
+			main {
+				/* background-color: aqua; */
+				gap: var(--spacing-md);
+			}
+			
 		}
 
+		@media screen and (max-aspect-ratio: 1271/1273) {
+			main {
+				max-height: 50rem;
+			}
 
+			.map {
+				height: 30vh !important;
+			}
+
+			ol {
+				background-color: blueviolet;
+			}
+			
+		}
+
+		@container carousel (max-aspect-ratio: 426/620) {
+			li {
+				width: 100%;
+			}
+		}
 	}
+
+	
 </style>

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -125,18 +125,12 @@
 	}
 
 	.map {
-		height: 50vh !important;
+		max-height: 50vh !important;
 		border-radius: var(--border-radius-md);
 		border: 5px solid var(--blue-300);
 	}
 
 	@media screen and (min-width: 800px) {
-		:global(body) {
-			height: 100vh; /* For big screens */
-			display: flex;
-			align-items: center;
-			/* background-color: aquamarine; */
-		}
 		main {
 			flex-wrap: nowrap;
 			max-height: calc(100vh - 6rem); /* 6rem = padding top */
@@ -176,7 +170,7 @@
 			}
 
 			.map {
-				height: 30vh !important;
+				max-height: 30vh !important;
 			}
 
 			ol {
@@ -190,7 +184,5 @@
 				width: 100%;
 			}
 		}
-	}
-
-	
+	}	
 </style>

--- a/src/routes/adressen/[id]/+page.svelte
+++ b/src/routes/adressen/[id]/+page.svelte
@@ -131,11 +131,18 @@
 		border: 5px solid var(--blue-300);
 	}
 
+
+
 	@media screen and (min-width: 800px) {
 		main {
 			flex-wrap: nowrap;
 			max-height: calc(100vh - 6rem); /* 6rem = padding top */
 			gap: var(--spacing-xl);
+		}
+
+		ol {
+			container-type: size;
+			container-name: carousel;
 		}
 
 		ol li {
@@ -148,5 +155,22 @@
 			height: 100% !important;
 			width: auto;	
 		}
+	}
+
+	@media screen and (max-aspect-ratio: 1120/898) {
+		main {
+			background-color: aqua;
+			gap: var(--spacing-md);
+		}
+		
+	}
+
+	@container carousel (max-aspect-ratio: 426/620) {
+		li {
+			background-color: aquamarine;
+			width: 100%;
+		}
+
+
 	}
 </style>


### PR DESCRIPTION
## What does this change?
- When there is one poster on the detail page it is centered
- More container queries so the posters aren't cut of (can be better)

Fix #260 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a GitHub issue over linking to it; the card may not always exist and reviewers may not have access to the board. -->


## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [X] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

![Schermafbeelding 2025-04-28 120627](https://github.com/user-attachments/assets/97b36922-4486-4c23-a738-8fd14f7f1027)
![Schermafbeelding 2025-04-28 120643](https://github.com/user-attachments/assets/d9eb8bca-4e1a-4803-aa57-704b5d7e6a29)
![Schermafbeelding 2025-04-28 120657](https://github.com/user-attachments/assets/6c6dabda-0d70-4e39-8534-80af9f3d06b4)

## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

src > routes > adressen > +page.svelte
