### PR TITLE
fix: #225 - Broken grid clumns

### DIFF
--- a/src/lib/organisms/PostersOverview.svelte
+++ b/src/lib/organisms/PostersOverview.svelte
@@ -57,7 +57,7 @@
 	}
 	ul {
 		display: grid;
-		grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+		grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
 		gap: var(--spacing-sm);
 		padding-top: var(--spacing-sm);
 	}

--- a/src/routes/adressen/+page.js
+++ b/src/routes/adressen/+page.js
@@ -4,7 +4,8 @@ import { readItems } from '@directus/sdk';
 export async function load({ fetch, url }) {
   // Initialize the filters
   let streetFilters = url.searchParams.getAll('s');
-  let nameFilters = url.searchParams.get('n').split(/\s+/).map(word => word.replace(/[.,!?]/g, ''));
+  let nameFilters = url.searchParams.get('n');
+  nameFilters = nameFilters ? nameFilters.split(/\s+/).map(word => word.replace(/[.,!?]/g, '')) : null;
   let queryFilters = {};
 
   // Add the street filters to the query


### PR DESCRIPTION
## What does this change?

Resolves issue
- #225

Fixed the broken grid layout when only one item is displayed, and the broken grid layout when transitioning from two columns to one. Also improved the error handling on the name searchbar.

## How Has This Been Tested?

- [ ] User test
- [ ] Accessibility test
- [ ] Performance test
- [x] Responsive Design test
- [ ] Device test
- [x] Browser test