### PR TITLE
Fix 275 fix non js filter component

### DIFF
--- a/src/lib/atoms/TextInput.svelte
+++ b/src/lib/atoms/TextInput.svelte
@@ -25,8 +25,8 @@
 		color: var(--neutral-900);
 		padding: var(--spacing-xxs) var(--spacing-sm);
 		border: none;
-		border-radius: var(--border-radius-pill);
-		border: 2px solid var(--blue-100);
+		border-radius: var(--border-radius-sm);
+		/* border: 3px solid var(--blue-600); */
 		text-overflow: ellipsis;
     height: 2.5rem;
 

--- a/src/lib/molecules/FilterSectionList.svelte
+++ b/src/lib/molecules/FilterSectionList.svelte
@@ -23,7 +23,7 @@
   fieldset {
     border: none;
     padding: 0;
-    margin: var(--spacing-md) 0 0 0;
+    /* margin: var(--spacing-md) 0 0 0; */
   }
 
   legend {

--- a/src/lib/molecules/FilterSectionList.svelte
+++ b/src/lib/molecules/FilterSectionList.svelte
@@ -24,6 +24,7 @@
     border: none;
     padding: 0;
     /* margin: var(--spacing-md) 0 0 0; */
+    display: flex;
   }
 
   legend {
@@ -35,14 +36,60 @@
 
   ul {
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
+    width: calc(100vw - var(--spacing-md)*2);
     gap: var(--spacing-xs);
     list-style: none;
+
+    /* SCROLLING */
+    overflow-y: hidden;
+    overflow-x: auto;
+    scroll-snap-type: x mandatory;		
+    scroll-behavior: smooth;
+    -webkit-overflow-scrolling: touch;
+
+    /* SCROLLBAR */
+    scrollbar-width: 0;
+
+    &::-webkit-scrollbar {
+      width: 0;
+    }
+
+    &::-webkit-scrollbar-track {
+      background: transparent;
+    }
+
+    &::-webkit-scrollbar-thumb {
+      background: transparent;
+      border: none;
+    }
   }
 
   li {
     display: flex;
     align-items: center;
-    gap: var(--spacing-xs);
+
+    gap: var(--spacing-xs); 
+    background-color: var(--blue-600);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    white-space: nowrap;
+    border-radius: var(--border-radius-sm);
+  }
+
+  @media screen and (min-width: 800px) {
+    ul {
+      flex-direction: column;
+      gap: var(--spacing-sm);
+      list-style: none;
+      width: fit-content;
+    }
+
+    li {
+      display: flex;
+      align-items: center;
+      gap: var(--spacing-xs);
+      background-color: transparent;
+      padding: 0;
+    }
   }
 </style>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -85,16 +85,12 @@ IF JS DISABLED SHOW DETAILS VERSION
 	aside {
 		display: block;
 		position: sticky;
-		top: 6rem;
+		top: 0;
 		left: 0;
 		background-color: var(--blue-500);
 		color: var(--white);
 		padding: var(--spacing-md) var(--spacing-md);
-
-		/* width: 100vw; */
-		/* overflow-y: auto; */
-		/* z-index: 100; */
-		/* transform: translateX(-100%); */
+		padding-bottom: var(--spacing-sm);
 		transition: transform 0.3s ease-in-out;
 	}
 
@@ -168,6 +164,7 @@ IF JS DISABLED SHOW DETAILS VERSION
 	@media screen and (min-width: 800px) {
 		aside {
 			position: sticky;
+			top: 6rem;
 			height: calc(100vh - 6rem);
 			width: 20rem;
 			transform: translateX(0);

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -44,7 +44,7 @@
 			buttonClass={$css('show-on-focus')}
 			type="submit"
 		>
-			Toepassen
+			Filter toepassen
 		</Button>
 	</form>
 </aside>
@@ -130,27 +130,33 @@ IF JS DISABLED SHOW DETAILS VERSION
 	} */
 
 	form {
-		display: grid !important;
-		grid-template-columns: 1fr auto;
-		grid-template-rows: auto auto;
-		gap: var(--spacing-md);
+		display: flex;
+		flex-direction: column;
+		/* grid-template-columns: 1fr auto;
+		grid-template-rows: auto auto; */
+		gap: var(--spacing-xs);
+		margin-top: var(--spacing-md);
 	}
 
-	form > div {
+	/* form > div {
 		grid-column: 1 / 3;
 		grid-row: 2;
-	}
+	} */
 
 	.show-on-focus:focus-visible {
-		position: static;
-		display: inline-block;
-		width: fit-content;
-		height: fit-content;
-		padding: var(--spacing-xxs) var(--spacing-sm);
-		overflow: visible;
-		clip: auto;
-		white-space: normal;
-		border-width: 0;
+		background-color: var(--blue-700) !important;
+	}
+
+	.show-on-focus {
+		background-color: var(--blue-600) !important;
+		border-radius: var(--border-radius-sm) !important;
+		box-shadow: none !important;
+		width: 100% !important;
+		margin-bottom: var(--spacing-xs);
+	}
+
+	.higlight {
+		background-color: var(--blue-200);
 	}
 
 	.hide-mobile {
@@ -163,7 +169,8 @@ IF JS DISABLED SHOW DETAILS VERSION
 
 	@media screen and (min-width: 800px) {
 		aside {
-			position: sticky;
+			display: flex;
+			flex-direction: column;
 			top: 6rem;
 			height: calc(100vh - 6rem);
 			width: 20rem;
@@ -182,6 +189,12 @@ IF JS DISABLED SHOW DETAILS VERSION
 
 		.filter-button {
 			display: none !important;
+		}
+
+		form {
+			margin-top: var(--spacing-lg);
+			gap: var(--spacing-lg);
+			height: 100%;
 		}
 	}
 </style>

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -27,17 +27,10 @@
 </script>
 
 <!-- IF JS ENABLED SHOW ASIDE VERSION -->
-<aside class={[filterOpen && 'open', !javascript.enabled && $css('hide-mobile')]}>
+<aside class={[filterOpen && 'open', !javascript.enabled]}> <!--  && $css('hide-mobile') -->
 	<h3>Filters</h3>
-  <h4>Vind adressen via een zoekterm, of filter op straatnaam.</h4>
+	<h4>Vind adressen via een zoekterm, of filter op straatnaam.</h4>
 	<form bind:this={formAside} action="/adressen" data-sveltekit-noscroll>
-		<Button
-			class={{ 'sr-only': javascript.enabled, highlight: true }}
-			buttonClass={$css('show-on-focus')}
-			type="submit"
-		>
-			Toepassen
-		</Button>
 		<div>
 			<FilterSectionList
 				title="Straat"
@@ -46,21 +39,6 @@
 				onchange={() => formAside.requestSubmit()}
 			/>
 		</div>
-	</form>
-</aside>
-
-<Button
-	onclick={() => (filterOpen = !filterOpen)}
-	class="highlight"
-	buttonClass={[$css('filter-button'), !javascript.enabled && $css('hide-mobile')]}>Filters</Button
->
-
-<!-- IF JS DISABLED SHOW DETAILS VERSION -->
-<details class={{ hidden: javascript.enabled, 'hide-desktop': !javascript.enabled }}>
-	<summary>
-		<h3>Filters</h3>
-	</summary>
-	<form bind:this={formDetails} action="/adressen" data-sveltekit-noscroll>
 		<Button
 			class={{ 'sr-only': javascript.enabled, highlight: true }}
 			buttonClass={$css('show-on-focus')}
@@ -68,6 +46,23 @@
 		>
 			Toepassen
 		</Button>
+	</form>
+</aside>
+<!-- <div class="filter-button-container">
+	<Button
+		onclick={() => (filterOpen = !filterOpen)}
+		class="highlight"
+		buttonClass={[$css('filter-button'), !javascript.enabled && $css('hide-mobile')]}>Filters </Button
+	>
+</div> -->
+
+<!--
+IF JS DISABLED SHOW DETAILS VERSION 
+<details class={{ hidden: javascript.enabled, 'hide-desktop': !javascript.enabled }}>
+	<summary>
+		<h3>Filters</h3>
+	</summary>
+	<form bind:this={formDetails} action="/adressen" data-sveltekit-noscroll>
 		<div>
 			<FilterSectionList
 				title="Straat"
@@ -76,23 +71,30 @@
 				onchange={() => formDetails.requestSubmit()}
 			/>
 		</div>
+		<Button
+			class={{ 'sr-only': javascript.enabled, highlight: true }}
+			buttonClass={$css('show-on-focus')}
+			type="submit"
+		>
+			Toepassen
+		</Button>
 	</form>
-</details>
+</details> -->
 
 <style>
 	aside {
 		display: block;
-		position: fixed;
+		position: sticky;
 		top: 6rem;
 		left: 0;
 		background-color: var(--blue-500);
 		color: var(--white);
-		padding: var(--spacing-lg) var(--spacing-md);
-		height: calc(100vh - 6rem);
-		width: 100vw;
-		overflow-y: auto;
-		z-index: 100;
-		transform: translateX(-100%);
+		padding: var(--spacing-md) var(--spacing-md);
+
+		/* width: 100vw; */
+		/* overflow-y: auto; */
+		/* z-index: 100; */
+		/* transform: translateX(-100%); */
 		transition: transform 0.3s ease-in-out;
 	}
 
@@ -109,8 +111,8 @@
 		font-weight: var(--font-weight-light);
 	}
 
-	.filter-button {
-		position: fixed;
+	/* .filter-button {
+		position: sticky;
 		top: calc(6rem + var(--spacing-md));
 		left: var(--page-padding);
 		z-index: 100;
@@ -118,13 +120,18 @@
 	}
 
 	aside.open + .filter-button {
-		/* Move button to right of screen */
 		transform: translateX(calc(100vw - 100% - var(--page-padding) * 2));
 	}
 
 	aside.open {
 		transform: translateX(0);
-	}
+	} */
+
+	/* .filter-button-container {
+		background-color: var(--blue-500);
+		width: 100%;
+		height: fit-content;
+	} */
 
 	form {
 		display: grid !important;
@@ -165,9 +172,10 @@
 			width: 20rem;
 			transform: translateX(0);
 			z-index: 0;
+			padding: var(--spacing-lg) var(--spacing-md);
 		}
 
-    .hide-mobile {
+		.hide-mobile {
 			display: block !important;
 		}
 

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -27,7 +27,7 @@
 </script>
 
 <!-- IF JS ENABLED SHOW ASIDE VERSION -->
-<aside class={[filterOpen && 'open', !javascript.enabled]}> <!--  && $css('hide-mobile') -->
+<aside class={[filterOpen && 'open', !javascript.enabled]}>
 	<h3>Filters</h3>
 	<h4>Vind adressen via een zoekterm, of filter op straatnaam.</h4>
 	<form bind:this={formAside} action="/adressen" data-sveltekit-noscroll>
@@ -48,38 +48,6 @@
 		</Button>
 	</form>
 </aside>
-<!-- <div class="filter-button-container">
-	<Button
-		onclick={() => (filterOpen = !filterOpen)}
-		class="highlight"
-		buttonClass={[$css('filter-button'), !javascript.enabled && $css('hide-mobile')]}>Filters </Button
-	>
-</div> -->
-
-<!--
-IF JS DISABLED SHOW DETAILS VERSION 
-<details class={{ hidden: javascript.enabled, 'hide-desktop': !javascript.enabled }}>
-	<summary>
-		<h3>Filters</h3>
-	</summary>
-	<form bind:this={formDetails} action="/adressen" data-sveltekit-noscroll>
-		<div>
-			<FilterSectionList
-				title="Straat"
-				name="s"
-				items={streets}
-				onchange={() => formDetails.requestSubmit()}
-			/>
-		</div>
-		<Button
-			class={{ 'sr-only': javascript.enabled, highlight: true }}
-			buttonClass={$css('show-on-focus')}
-			type="submit"
-		>
-			Toepassen
-		</Button>
-	</form>
-</details> -->
 
 <style>
 	aside {
@@ -107,41 +75,12 @@ IF JS DISABLED SHOW DETAILS VERSION
 		font-weight: var(--font-weight-light);
 	}
 
-	/* .filter-button {
-		position: sticky;
-		top: calc(6rem + var(--spacing-md));
-		left: var(--page-padding);
-		z-index: 100;
-		transition: all 0.3s ease-in-out !important;
-	}
-
-	aside.open + .filter-button {
-		transform: translateX(calc(100vw - 100% - var(--page-padding) * 2));
-	}
-
-	aside.open {
-		transform: translateX(0);
-	} */
-
-	/* .filter-button-container {
-		background-color: var(--blue-500);
-		width: 100%;
-		height: fit-content;
-	} */
-
 	form {
 		display: flex;
 		flex-direction: column;
-		/* grid-template-columns: 1fr auto;
-		grid-template-rows: auto auto; */
 		gap: var(--spacing-xs);
 		margin-top: var(--spacing-md);
 	}
-
-	/* form > div {
-		grid-column: 1 / 3;
-		grid-row: 2;
-	} */
 
 	.show-on-focus:focus-visible {
 		background-color: var(--blue-700) !important;

--- a/src/lib/organisms/SideFilter.svelte
+++ b/src/lib/organisms/SideFilter.svelte
@@ -54,7 +54,7 @@
 	aside {
 		display: block;
 		position: sticky;
-		top: 0;
+		top: -8rem;
 		left: 0;
 		background-color: var(--blue-500);
 		color: var(--white);

--- a/src/routes/adressen/+page.svelte
+++ b/src/routes/adressen/+page.svelte
@@ -27,7 +27,7 @@
 	border-bottom: 5px solid var(--blue-300);
   }
 
-	@media screen and (min-width: 460px) {
+	@media screen and (min-width: 800px) {
 		main {
 			margin: 0 auto;
 			display: grid;


### PR DESCRIPTION
## What does this change?
- Deleted detail button when JS is disabled
- Deleted filter button menu when JS
- Filter on mobile is now under the map
- Straat filter is now sticky
- Different styling for 'filter toepassen' button for JS disabled
- Changed 'toepassen' button to 'filter toepassen'

Fix #275 

## How Has This Been Tested?

- [ ] User test
- [X] Accessibility test
- [ ] Performance test
- [X] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->
### JS
#### Desktop
![image](https://github.com/user-attachments/assets/a08b4944-0eed-49b5-b202-4a77bda7dd1f)

#### Mobile
![Afbeelding van WhatsApp op 2025-04-28 om 14 57 23_dd0661bf](https://github.com/user-attachments/assets/bb63bbef-6866-4578-a7c7-f6364e2f53ec)
![Afbeelding van WhatsApp op 2025-04-28 om 14 58 49_f6c487d6](https://github.com/user-attachments/assets/fded32b4-2ffa-4dc6-9d5e-bbdc5a0eae3c)

> Straat filter is sticky


### Non JS
#### Desktop
![Afbeelding van WhatsApp op 2025-04-28 om 15 41 19_22c43749](https://github.com/user-attachments/assets/37ff4cb3-3762-42aa-8ac6-0fc8e64f9893)

#### Mobile
![Afbeelding van WhatsApp op 2025-04-28 om 15 42 15_6a5a68b7](https://github.com/user-attachments/assets/6f894646-f4b2-4022-99c8-91532bf77ed8)


## How to review

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

- Molecules > FilterSectionList.svelte
- Organisms > SideFilter.svelte
- Adressen > +page.svelte
