### PR TITLE
feat: #199 - Improved map marker popups

### DIFF
--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -32,7 +32,11 @@
     markers = [];
 
     mapAddresses.forEach((marker) => {
-      const popUpInfo = `<strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}`;
+      console.log(marker);
+      const popup = new L.popup({
+      });
+
+      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img style="width: 100%; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" class="button">Bekijk poster</a></div>`);
       
       const customIcon = leaflet.icon({
         iconUrl: (activeMapAddresses ? '/assets/icons/marker-inactive.svg' : '/assets/icons/marker.svg'),
@@ -44,7 +48,7 @@
           icon: customIcon
         })
         .addTo(map)
-        .bindPopup(popUpInfo);
+        .bindPopup(popup);
         
       markers.push(newMarker);
     });

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -32,11 +32,9 @@
     markers = [];
 
     mapAddresses.forEach((marker) => {
-      console.log(marker);
-      const popup = new L.popup({
-      });
+      const popup = new L.popup({});
 
-      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img style="width: 100%; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" class="button">Bekijk poster</a></div>`);
+      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img style="width: 100%; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" data-sveltekit-reload>Bekijk poster</a></div>`);
       
       const customIcon = leaflet.icon({
         iconUrl: (activeMapAddresses ? '/assets/icons/marker-inactive.svg' : '/assets/icons/marker.svg'),
@@ -54,7 +52,9 @@
     });
 
     activeMapAddresses.forEach((marker) => {
-      const popUpInfo = `<strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}`;
+      const popup = new L.popup({});
+
+      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img style="width: 100%; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" data-sveltekit-reload>Bekijk poster</a></div>`);
       
       const customIcon = leaflet.icon({
         iconUrl: '/assets/icons/marker-active.svg',
@@ -68,7 +68,7 @@
           zIndexOffset: 10000 
         })
         .addTo(map)
-        .bindPopup(popUpInfo);
+        .bindPopup(popup);
         
         markers.push(newMarker);
     });

--- a/src/lib/organisms/Map.svelte
+++ b/src/lib/organisms/Map.svelte
@@ -34,7 +34,7 @@
     mapAddresses.forEach((marker) => {
       const popup = new L.popup({});
 
-      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img style="width: 100%; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" data-sveltekit-reload>Bekijk poster</a></div>`);
+      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img width="${marker.poster.covers[0].directus_files_id.width}" height="${marker.poster.covers[0].directus_files_id.height}" style="width: 100%; height: auto; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" data-sveltekit-reload>Bekijk poster</a></div>`);
       
       const customIcon = leaflet.icon({
         iconUrl: (activeMapAddresses ? '/assets/icons/marker-inactive.svg' : '/assets/icons/marker.svg'),
@@ -54,7 +54,7 @@
     activeMapAddresses.forEach((marker) => {
       const popup = new L.popup({});
 
-      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img style="width: 100%; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" data-sveltekit-reload>Bekijk poster</a></div>`);
+      popup.setContent(`<div style="width: 100px;"><p><strong>${marker.street}</strong> ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}</p><img width="${marker.poster.covers[0].directus_files_id.width}" height="${marker.poster.covers[0].directus_files_id.height}" style="width: 100%; height: auto; margin-bottom: 0.75rem;" src="https://fdnd-agency.directus.app/assets/${marker.poster.covers[0].directus_files_id.id}" alt="Afbeelding van ${marker.street} ${marker.house_number} ${marker.floor ?? ''} ${marker.addition ?? ''}"><a href="/adressen/${marker.id}" data-sveltekit-reload>Bekijk poster</a></div>`);
       
       const customIcon = leaflet.icon({
         iconUrl: '/assets/icons/marker-active.svg',

--- a/src/routes/adressen/[id]/+page.server.js
+++ b/src/routes/adressen/[id]/+page.server.js
@@ -45,6 +45,18 @@ export async function load({ fetch, params }) {
 						'floor',
 						'addition',
 						'map',
+            {
+							poster: [
+								'id',
+								{
+									covers: [
+										'directus_files_id.id',
+										'directus_files_id.width',
+										'directus_files_id.height'
+									]
+								}
+							]
+						}
 					]
 				})
 			)


### PR DESCRIPTION
## What does this change?

Resolves issue
- #199 

Improved the styling on map marker popups, now providing a preview of the poster, and a link to navigate to the poster's detail page.

## How Has This Been Tested?

- [ ] User test
- [x] Accessibility test
- [x] Performance test
- [x] Responsive Design test
- [ ] Device test
- [ ] Browser test

## Images

![image](https://github.com/user-attachments/assets/e94c04de-6ba0-46dc-b79d-08663ed3fdc4)

