### PR TITLE
feat: #294 - Repopulate search bar on navigate (no clientside JS)

### DIFF
--- a/src/lib/molecules/FilterSearchbar.svelte
+++ b/src/lib/molecules/FilterSearchbar.svelte
@@ -3,8 +3,10 @@
   import Button from '$lib/atoms/Button.svelte';
   import Checkbox from '$lib/atoms/Checkbox.svelte';
   import { onMount } from 'svelte';
-
+  import { page } from '$app/state';
   let { title, onevent, name, formRef} = $props();
+
+  let activeSearch = $derived(page.url.searchParams.get('n'));
 
   let searchTimeout;
   let inputRef;
@@ -25,6 +27,7 @@
   <TextInput 
     id="search" 
     placeholder="Jacob..." 
+    value={activeSearch}
     sronly={true} 
     name="n" 
     inputClass={$css('input')}


### PR DESCRIPTION
## What does this change?

Resolves issue #294

Made it so that the search bar in the filter gets repopulated based on the search params when a navigation occurs. Works even without javascript enabled.
