### PR TITLE
fix: Fixed centered homepage h2 on firefox 🐛

### DIFF
--- a/src/lib/organisms/PostersCarousel.svelte
+++ b/src/lib/organisms/PostersCarousel.svelte
@@ -29,6 +29,7 @@
 		gap: var(--spacing-sm);
 		overflow-x: auto;
 		scroll-snap-type: x mandatory;
+    width: 100%;
 	}
 
 	.carousel-item {

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -35,7 +35,7 @@
 	</header>
 
 	<div class="page-content">
-		<section>
+		<section class="section-suggested">
 			<h3>Uitgelichte gedenkposters</h3>
 	
 			<PostersCarousel {addresses} />
@@ -115,12 +115,12 @@
 	section {
 		margin-bottom: var(--spacing-md);
 		padding: var(--spacing-md) 0;
+    display: flex;
+		flex-direction: column;
+    align-items: center;
 	}
 
 	.section-CTA {
-		display: flex;
-		flex-direction: column;
-		align-items: center;
 		background-color: var(--blue-200);
 		margin-bottom: 0;
 	}


### PR DESCRIPTION
## What does this change?

Resolves issue 
- #300

Fixed h2 on homepage not centering properly on firefox by applying a flexbox style to its parent.